### PR TITLE
fix: expunge lost workers from session in WorkerRepository

### DIFF
--- a/src/manman/repository/database.py
+++ b/src/manman/repository/database.py
@@ -338,6 +338,8 @@ class WorkerRepository(DatabaseRepository):
                     open_worker_condition, last_status.c.status_type == StatusType.LOST
                 )
             ).all()
+            for worker in lost_workers:
+                session.expunge(worker)
 
             update_stmt = (
                 update(Worker).where(open_worker_condition).values(end_date=func.now())


### PR DESCRIPTION
This pull request introduces a small but important change to the `close_other_workers` method in `src/manman/repository/database.py`. The change ensures that workers marked as "lost" are detached from the current session using `session.expunge`, which can help prevent unintended side effects when interacting with these objects later in the code.