### PR TITLE
fix: update lost Status instantiation to use create method

### DIFF
--- a/src/manman/host/status_processor.py
+++ b/src/manman/host/status_processor.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from amqpstorm import Connection
 
@@ -212,10 +212,9 @@ class StatusEventProcessor:
         """Send a worker lost notification to external queue"""
         try:
             # Create a status message indicating the worker is lost
-            lost_status = ExternalStatusInfo(
+            lost_status = ExternalStatusInfo.create(
                 class_name="StatusEventProcessor",
                 status_type=StatusType.LOST,
-                as_of=datetime.now(timezone.utc),
                 worker_id=worker_id,
             )
 
@@ -232,10 +231,9 @@ class StatusEventProcessor:
         """Send a game server lost notification to external queue"""
         try:
             # Create a status message indicating the game server instance is lost
-            lost_status = ExternalStatusInfo(
+            lost_status = ExternalStatusInfo.create(
                 class_name="StatusEventProcessor",
                 status_type=StatusType.LOST,
-                as_of=datetime.now(timezone.utc),
                 game_server_instance_id=game_server_instance_id,
             )
 


### PR DESCRIPTION
This pull request refactors the `status_processor.py` file to simplify the creation of `ExternalStatusInfo` objects and removes an unused import. The most important changes are as follows:

### Refactoring for `ExternalStatusInfo` creation:
* Replaced direct instantiation of `ExternalStatusInfo` with the `create` class method in `_send_worker_lost_notification` and `_send_game_server_lost_notification` methods to standardize object creation. (`src/manman/host/status_processor.py`, [[1]](diffhunk://#diff-5aa9c2d45d71408a30b8a794da1055d6e705d62516a5f8f0a3b633bf771f4c93L215-L218) [[2]](diffhunk://#diff-5aa9c2d45d71408a30b8a794da1055d6e705d62516a5f8f0a3b633bf771f4c93L235-L238)

### Code cleanup:
* Removed the unused `timezone` import from `datetime` to clean up the imports. (`src/manman/host/status_processor.py`, [src/manman/host/status_processor.pyL3-R3](diffhunk://#diff-5aa9c2d45d71408a30b8a794da1055d6e705d62516a5f8f0a3b633bf771f4c93L3-R3))